### PR TITLE
Cap ONNX version at 1.15.0

### DIFF
--- a/openaiCLIP-to-onnx/requirements.txt
+++ b/openaiCLIP-to-onnx/requirements.txt
@@ -3,3 +3,4 @@ torch
 onnxruntime
 onnxsim
 sclblonnx
+onnx<=1.15.0

--- a/timm-to-onnx/requirements.txt
+++ b/timm-to-onnx/requirements.txt
@@ -2,3 +2,4 @@ timm
 sclblonnx
 torch
 onnxsim
+onnx<=1.15.0

--- a/ultralytics-to-onnx/requirements.txt
+++ b/ultralytics-to-onnx/requirements.txt
@@ -1,5 +1,5 @@
 sclblonnx==0.2.1
-onnx==1.13.1
+onnx>=1.13.1,<=1.15.0
 onnx-simplifier==0.4.35
 onnxoptimizer==0.3.13
 onnxruntime==1.20.1

--- a/yolov10-to-onnx/requirements.txt
+++ b/yolov10-to-onnx/requirements.txt
@@ -1,4 +1,4 @@
-onnx==1.13.1
+onnx>=1.13.1,<=1.15.0
 onnx-simplifier==0.4.35
 onnxoptimizer==0.3.13
 sclblonnx==0.2.1

--- a/yolov12-to-onnx/requirements.txt
+++ b/yolov12-to-onnx/requirements.txt
@@ -1,5 +1,5 @@
 sclblonnx==0.3.0
-onnx==1.14.0
+onnx>=1.14.0,<=1.15.0
 onnx-simplifier==0.4.35
 onnxoptimizer==0.3.13
 ultralytics @ git+https://github.com/sunsmarterjie/yolov12

--- a/yolov5-to-onnx/requirements.txt
+++ b/yolov5-to-onnx/requirements.txt
@@ -1,4 +1,4 @@
-onnx==1.13.1
+onnx>=1.13.1,<=1.15.0
 onnx-simplifier==0.4.35
 onnxoptimizer==0.3.13
 onnxruntime==1.17.0

--- a/yolov9-to-onnx/requirements.txt
+++ b/yolov9-to-onnx/requirements.txt
@@ -1,4 +1,4 @@
-onnx
+onnx<=1.15.0
 onnxsim
 sclblonnx
 onnxruntime

--- a/yolox-to-onnx/YOLOX/requirements.txt
+++ b/yolox-to-onnx/YOLOX/requirements.txt
@@ -14,5 +14,5 @@ tensorboard
 # verified versions
 # pycocotools corresponds to https://github.com/ppwwyyxx/cocoapi
 pycocotools>=2.0.2
-onnx>=1.13.0
+onnx>=1.13.0,<=1.15.0
 onnx-simplifier==0.4.10

--- a/yolox-to-onnx/requirements.txt
+++ b/yolox-to-onnx/requirements.txt
@@ -1,4 +1,4 @@
-onnx==1.13.1
+onnx>=1.13.1,<=1.15.0
 onnx-simplifier==0.4.35
 onnxoptimizer==0.3.13
 onnxruntime==1.17.0


### PR DESCRIPTION
The versions newer than 1.15.0 are not supported by Nx AI Manager.